### PR TITLE
Take the snapshot after updates have completed, allowing any UI animations/updates to complete first

### DIFF
--- a/Pod/Classes/AppViewController.swift
+++ b/Pod/Classes/AppViewController.swift
@@ -106,8 +106,8 @@ fileprivate extension AppViewController {
         // resign any active first responder before continuing
         window.resignCurrentFirstResponderIfNeeded {
             
-            // take a snapshot of the window state
-            let snapshot = window.snapshotView(afterScreenUpdates: false)
+            // take a snapshot of the window state, allowing any updates to the UI to complete
+            let snapshot = window.snapshotView(afterScreenUpdates: true)
             snapshot?.tag = transitionSnapshotTag
             
             // cover the window with the snapshot


### PR DESCRIPTION
Fixes an issue where changes to the UI that may not have completed, like animations, may not have completed when this call is made, resulting in an inaccurate snapshot.